### PR TITLE
fix cargo install command in README, fix compatibility break of serde

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the [examples](examples) directory for full working examples in each style.
 In case you have [Rust](https://www.rust-lang.org/) installed, you can install with `cargo`:
 
 ```
-cargo install --git https://github.com/mlange-42/yarner
+cargo install --git https://github.com/mlange-42/yarner yarner --features bin
 ```
 
 ## Getting started

--- a/src/document/text.rs
+++ b/src/document/text.rs
@@ -1,6 +1,6 @@
 //! Representation of the text parts of the AST
 
-use serde::export::Formatter;
+use core::fmt::Formatter;
 use std::fmt::Display;
 
 /// A `TextBlock` is just text that will be copied verbatim into the output documentation file


### PR DESCRIPTION
* Fix cargo install command in README
* Fix compatibility break of serde (`serde::export` no more public)