### PR TITLE
User control over inclusion of linked files

### DIFF
--- a/docs/Features.md
+++ b/docs/Features.md
@@ -6,8 +6,8 @@ Features in Markdown code blocks:
 * [Named entrypoints](#named-entrypoints)
 * [Comment extraction](#extracted-comments)
 * [Multiple files, multiple entrypoints](#multiple-files-multiple-entrypoints)
-* [File transclusions](#file-transclusions) (Markdown)
-* [Include linked files](#include-linked-files) (Markdown)
+* [File transclusions](#file-transclusions)
+* [Include linked files](#include-linked-files)
 * [Dead and hidden code blocks](#dead-and-hidden-code-blocks)
 * [Multiple languages in one file](#multiple-languages)
 * [Meta variables](#meta-variables)
@@ -115,15 +115,13 @@ It is not required that transcluded files have their own entrypoints. All code b
 
 ## Include linked files
 
-Files linked from the main source document are included in the compilation process.
-
-As an example, Yarner would also compile the file `src/main.rs.md` here:
+Files linked with a certain prefix (`@` by default) are included in the compilation process. As an example, Yarner would also compile the file `src/main.rs.md` here:
 
 ```md
-* [src/main.rs](src/main.rs.md)
+* @[src/main.rs](src/main.rs.md)
 ```
 
-However, files are only included in the compilation if they are referenced by a *relative path*, and the file exists in that location.
+However, files are only included in the compilation if they are referenced by a *relative path*, and the file exists in that location. The prefix is removed before writing documentation output.
 
 ## Dead and hidden code blocks
 

--- a/examples/default_setup/Yarner.toml
+++ b/examples/default_setup/Yarner.toml
@@ -31,6 +31,10 @@ transclusion_start = "@{{"
 # The sequence to identify the end of a transclusion.
 transclusion_end = "}}"
 
+# Prefix for links that should be followed during processing.
+# Should be RegEx-compatible.
+link_prefix = "@"
+
 # The sequence to split variables into name and value.
 variable_sep = ":"
 

--- a/examples/default_setup/docs/README.md.md
+++ b/examples/default_setup/docs/README.md.md
@@ -1,4 +1,4 @@
-# Markdown yarner template
+# Yarner template
 
 The following code goes to the base file of code output:
 

--- a/examples/features_demo/README.md.md
+++ b/examples/features_demo/README.md.md
@@ -62,4 +62,4 @@ For the first one, we use file transclusions. In the complied documentation in s
 
 @{{[Cargo.toml.md](Cargo.toml.md)}}
 
-Linked files are also included in the compilation process if the link is relative and the file exists. By linking to file [.gitignore.md](.gitignore.md), we use this feature to include it into processing.
+Files linked with a certain prefix (`@` by default) are also included in the compilation process if the link is relative and the file exists. By linking to file @[.gitignore.md](.gitignore.md), we use this feature to include it into processing. The prefixed is removed in documentation output.

--- a/examples/features_demo/Yarner.toml
+++ b/examples/features_demo/Yarner.toml
@@ -31,6 +31,10 @@ transclusion_start = "@{{"
 # The sequence to identify the end of a transclusion.
 transclusion_end = "}}"
 
+# Prefix for links that should be followed during processing.
+# Should be RegEx-compatible.
+link_prefix = "@"
+
 # The sequence to split variables into name and value.
 variable_sep = ":"
 

--- a/examples/features_demo/docs/README.md.md
+++ b/examples/features_demo/docs/README.md.md
@@ -71,4 +71,4 @@ authors = ["Your Name <you@example.com>"]
 edition = "2018"
 ```
 
-Linked files are also included in the compilation process if the link is relative and the file exists. By linking to file [.gitignore.md](.gitignore.md), we use this feature to include it into processing.
+Files linked with a certain prefix (`@` by default) are also included in the compilation process if the link is relative and the file exists. By linking to file [.gitignore.md](.gitignore.md), we use this feature to include it into processing. The prefixed is removed in documentation output.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Top-leven config
-#[derive(Serialize, Deserialize, Default, Debug)]
+#[derive(Deserialize, Default, Debug)]
 pub struct AnyConfig {
     /// Config for Markdown parser
     pub parser: MdParser,

--- a/src/document/ast.rs
+++ b/src/document/ast.rs
@@ -72,9 +72,21 @@ impl Ast {
         code_blocks
     }
     /// Gets all the text blocks of this AST
+    #[allow(dead_code)]
     pub(crate) fn text_blocks(&self) -> Vec<&TextBlock> {
         self.nodes
             .iter()
+            .filter_map(|node| match node {
+                Node::Text(block) => Some(block),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Gets all the text blocks of this AST
+    pub(crate) fn text_blocks_mut(&mut self) -> Vec<&mut TextBlock> {
+        self.nodes
+            .iter_mut()
             .filter_map(|node| match node {
                 Node::Text(block) => Some(block),
                 _ => None,

--- a/src/document/text.rs
+++ b/src/document/text.rs
@@ -24,6 +24,11 @@ impl TextBlock {
     pub fn lines(&self) -> &Vec<String> {
         &self.text
     }
+
+    /// Renders this `TextBlock` as the text it represents
+    pub fn lines_mut(&mut self) -> &mut Vec<String> {
+        &mut self.text
+    }
 }
 
 impl Display for TextBlock {

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,7 +453,7 @@ where
 {
     if !track_input_files.contains(file_name) {
         let mut document = transclude(parser, file_name, None)?;
-        let links = parser.find_links(&document, file_name)?;
+        let links = parser.find_links(&mut document, file_name)?;
 
         let file_str = file_name.to_str().unwrap();
         document.tree_mut().set_source(file_str);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -50,7 +50,8 @@ pub trait Parser: ParserConfig {
     fn parse(&self, input: &str) -> Result<Document, Self::Error>;
 
     /// Find all files linked into the document for later compilation and/or transclusion.
-    fn find_links(&self, input: &Document, from: &PathBuf) -> Result<Vec<PathBuf>, Self::Error>;
+    fn find_links(&self, input: &mut Document, from: &PathBuf)
+        -> Result<Vec<PathBuf>, Self::Error>;
 
     /// Parses a macro name, returning the name and the extracted variables
     #[allow(clippy::type_complexity)]

--- a/src/templates/Yarner-md.toml
+++ b/src/templates/Yarner-md.toml
@@ -31,6 +31,10 @@ transclusion_start = "@{{"
 # The sequence to identify the end of a transclusion.
 transclusion_end = "}}"
 
+# Prefix for links that should be followed during processing.
+# Should be RegEx-compatible.
+link_prefix = "@"
+
 # The sequence to split variables into name and value.
 variable_sep = ":"
 


### PR DESCRIPTION
Follow only links a with a certain prefix (`@` by default) to include them in the compilation process.

Example: `@[file.md](file.md)` would be included, while `[file.md](file.md)` would not.