### PR TITLE
Use panic=abort instead of the default panic=unwind for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 edition = "2018"
 
 [profile.release]
+panic = "abort"
 opt-level = "s"
 lto = true
 codegen-units = 1


### PR DESCRIPTION
Since we do not rely on unwinding to clean up external resources, panic=abort gives a nice little extra code density.