### PR TITLE
Reverted to use the (name, blocks) map to collect entrypoints

### DIFF
--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -10,6 +10,7 @@ use self::transclusion::Transclusion;
 use crate::config::LanguageSettings;
 use crate::parser::{code::RevCodeBlock, md::MdParser};
 use std::collections::hash_map::{Entry, HashMap};
+use std::fmt::Write;
 
 /// A representation of a `Document` of literate code
 #[derive(Debug)]
@@ -161,25 +162,27 @@ impl Document {
                     };
 
                     if !clean {
-                        if idx == 0 || block.name != blocks[idx - 1].name {
-                            result.push_str(&format!(
-                                "{} {}{}#{}{}\n",
-                                comment_start, block_start, path, name, comment_end,
-                            ));
+                        let sep = if idx == 0 || block.name != blocks[idx - 1].name {
+                            &block_start
                         } else {
-                            result.push_str(&format!(
-                                "{} {}{}#{}{}\n",
-                                comment_start, block_next, path, name, comment_end,
-                            ));
-                        }
+                            &block_next
+                        };
+                        writeln!(
+                            result,
+                            "{} {}{}#{}{}",
+                            comment_start, sep, path, name, comment_end,
+                        )
+                        .unwrap();
                     }
                     result.push_str(&block.compile(&code_blocks, settings)?);
                     result.push('\n');
                     if !clean && (idx == blocks.len() - 1 || block.name != blocks[idx + 1].name) {
-                        result.push_str(&format!(
+                        write!(
+                            result,
                             "{} {}{}#{}{}",
                             comment_start, block_end, path, name, comment_end,
-                        ));
+                        )
+                        .unwrap();
                     }
                 }
             }

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -241,7 +241,7 @@ impl Document {
         })
     }
 
-    pub fn code_blocks_by_name<'a>(
+    fn code_blocks_by_name<'a>(
         &'a self,
         language: Option<&'a str>,
     ) -> HashMap<Option<&'a str>, Vec<&'a CodeBlock>> {

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -140,6 +140,7 @@ impl Document {
             .unwrap_or("");
         let block_start = settings.map(|s| &s.block_start[..]).unwrap_or("");
         let block_end = settings.map(|s| &s.block_end[..]).unwrap_or("");
+        let block_next = settings.map(|s| &s.block_next[..]).unwrap_or("");
 
         let clean = if let Some(s) = settings {
             s.clean_code
@@ -151,7 +152,7 @@ impl Document {
         let mut result = String::new();
         match code_blocks.get(&entrypoint) {
             Some(blocks) => {
-                for block in blocks {
+                for (idx, block) in blocks.iter().enumerate() {
                     let path = block.source_file.to_owned().unwrap_or_default();
                     let name = if block.is_unnamed {
                         ""
@@ -160,14 +161,21 @@ impl Document {
                     };
 
                     if !clean {
-                        result.push_str(&format!(
-                            "{} {}{}#{}{}\n",
-                            comment_start, block_start, path, name, comment_end,
-                        ));
+                        if idx == 0 || block.name != blocks[idx - 1].name {
+                            result.push_str(&format!(
+                                "{} {}{}#{}{}\n",
+                                comment_start, block_start, path, name, comment_end,
+                            ));
+                        } else {
+                            result.push_str(&format!(
+                                "{} {}{}#{}{}\n",
+                                comment_start, block_next, path, name, comment_end,
+                            ));
+                        }
                     }
                     result.push_str(&block.compile(&code_blocks, settings)?);
                     result.push('\n');
-                    if !clean {
+                    if !clean && (idx == blocks.len() - 1 || block.name != blocks[idx + 1].name) {
                         result.push_str(&format!(
                             "{} {}{}#{}{}",
                             comment_start, block_end, path, name, comment_end,

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -230,7 +230,7 @@ impl Document {
         })
     }
 
-    fn code_blocks_by_name<'a>(
+    pub fn code_blocks_by_name<'a>(
         &'a self,
         language: Option<&'a str>,
     ) -> HashMap<Option<&'a str>, Vec<&'a CodeBlock>> {

--- a/src/parser/md.rs
+++ b/src/parser/md.rs
@@ -558,8 +558,8 @@ impl MdParser {
     ) -> Vec<(String, String)> {
         let mut entries = vec![];
         let pref = &self.file_prefix;
-        for block in doc.code_blocks(language) {
-            if let Some(name) = &block.name {
+        for (name, _block) in doc.code_blocks_by_name(language) {
+            if let Some(name) = name {
                 if let Some(rest) = name.strip_prefix(pref) {
                     entries.push((name.to_owned(), rest.to_owned()))
                 }

--- a/src/parser/md.rs
+++ b/src/parser/md.rs
@@ -33,6 +33,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Write;
 use std::fs::File;
@@ -551,17 +552,17 @@ impl MdParser {
     }
 
     /// Finds all file-specific entry points
-    pub fn get_entry_points(
+    pub fn get_entry_points<'a>(
         &self,
-        doc: &Document,
-        language: Option<&str>,
-    ) -> Vec<(String, String)> {
-        let mut entries = vec![];
+        doc: &'a Document,
+        language: Option<&'a str>,
+    ) -> HashMap<&'a str, &'a str> {
+        let mut entries = HashMap::new();
         let pref = &self.file_prefix;
-        for (name, _block) in doc.code_blocks_by_name(language) {
-            if let Some(name) = name {
+        for block in doc.code_blocks(language) {
+            if let Some(name) = &block.name {
                 if let Some(rest) = name.strip_prefix(pref) {
-                    entries.push((name.to_owned(), rest.to_owned()))
+                    entries.insert(name.as_str(), rest);
                 }
             }
         }


### PR DESCRIPTION
Required to allow for multiple equal-named blocks that are entrypoints.