### PR TITLE
List skipped files (no code blocks in reverse mode) instead of saying we write back to them

### DIFF
--- a/examples/rust/.gitignore.md
+++ b/examples/rust/.gitignore.md
@@ -1,5 +1,8 @@
 For a simple Rust project, we only need to ignore folder `target`:
 
 ```
+//- Main
 /target/
 ```
+
+We need to name this code block, because we have set option `entrypoint` in the `Yarner.toml` in order to avoid writing the blocks to the code output that show the Yarner commands in [README.md](README.md).

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,12 +340,14 @@ fn reverse(
             })
             .collect();
 
-        let print = doc.print_reverse(&config.parser, &blocks);
-
-        eprintln!("  Writing back to file {}", path.display());
-
-        let mut file = File::create(path).unwrap();
-        write!(file, "{}", print).unwrap()
+        if !blocks.is_empty() {
+            let print = doc.print_reverse(&config.parser, &blocks);
+            eprintln!("  Writing back to file {}", path.display());
+            let mut file = File::create(path).unwrap();
+            write!(file, "{}", print).unwrap()
+        } else {
+            eprintln!("  Skipping file {}", path.display());
+        }
     }
 
     Ok(())


### PR DESCRIPTION
further: fix rust example for entrypoint