### PR TITLE
Track code files over all input patterns and prevent multiple writes

### DIFF
--- a/guide/src/blocks-and-macros.md
+++ b/guide/src/blocks-and-macros.md
@@ -49,7 +49,7 @@ fn main() {
 
 ### File extensions
 
-However, a Rust file without the `.rs` extension is not very useful. We can rename the main file from `README.md` to `main.rs.md`.
+A Rust file without the `.rs` extension is not very useful. We can rename the main file from `README.md` to `main.rs.md`.
 Further, in file `Yarner.toml`, we change option `files` in section `[paths]` to:
 
 ```toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,6 +362,7 @@ fn process_inputs_forward(
     language: Option<&str>,
 ) -> Result<(), String> {
     let mut any_input = false;
+    let mut track_code_files = HashSet::new();
     for pattern in input_patterns {
         let paths = match glob::glob(&pattern) {
             Ok(p) => p,
@@ -407,7 +408,7 @@ fn process_inputs_forward(
                     language,
                     &config.language,
                     &mut HashSet::new(),
-                    &mut HashSet::new(),
+                    &mut track_code_files,
                 ) {
                     return Err(format!(
                         "Failed to compile source file \"{}\": {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,7 @@ fn process_inputs_forward(
     language: Option<&str>,
 ) -> Result<(), String> {
     let mut any_input = false;
-    let mut track_code_files = HashSet::new();
+    let mut track_code_files = HashMap::new();
     for pattern in input_patterns {
         let paths = match glob::glob(&pattern) {
             Ok(p) => p,
@@ -594,7 +594,7 @@ fn compile_all(
     language: Option<&str>,
     settings: &HashMap<String, LanguageSettings>,
     track_input_files: &mut HashSet<PathBuf>,
-    track_code_files: &mut HashSet<PathBuf>,
+    track_code_files: &mut HashMap<PathBuf, Option<PathBuf>>,
 ) -> Fallible {
     if !track_input_files.contains(file_name) {
         let mut document = transclude(parser, file_name)?;
@@ -709,14 +709,17 @@ fn compile(
     entrypoint: Option<&str>,
     language: Option<&str>,
     settings: &HashMap<String, LanguageSettings>,
-    track_code_files: &mut HashSet<PathBuf>,
+    track_code_files: &mut HashMap<PathBuf, Option<PathBuf>>,
 ) -> Fallible {
     eprintln!("Compiling file {}", file_name.display());
 
     let mut entries = parser.get_entry_points(&document, language);
 
     let file_name_without_ext = file_name.with_extension("");
-    entries.insert(entrypoint, &file_name_without_ext);
+    entries.insert(
+        entrypoint,
+        (&file_name_without_ext, Some(file_name.to_owned())),
+    );
 
     match doc_dir {
         Some(doc_dir) => {
@@ -730,7 +733,7 @@ fn compile(
         None => eprintln!("WARNING: Missing output location for docs, skipping docs output."),
     }
 
-    for (entrypoint, sub_file_name) in entries {
+    for (entrypoint, (sub_file_name, sub_source_file)) in entries {
         match code_dir {
             Some(code_dir) => {
                 let mut file_path = code_dir.to_owned();
@@ -746,14 +749,22 @@ fn compile(
                     .to_string();
                 let settings = settings.get(&extension);
 
-                if track_code_files.contains(&file_path) {
-                    return Err(format!(
-                        "Multiple locations point to code file {}",
-                        file_path.display()
-                    )
-                    .into());
-                } else {
-                    track_code_files.insert(file_path.clone());
+                match track_code_files.entry(file_path.clone()) {
+                    Occupied(entry) => {
+                        if sub_source_file == *entry.get() {
+                            eprintln!("  Skipping file {} (already written)", file_path.display());
+                            continue;
+                        } else {
+                            return Err(format!(
+                                "Multiple distinct locations point to code file {}",
+                                file_path.display()
+                            )
+                            .into());
+                        }
+                    }
+                    Vacant(entry) => {
+                        entry.insert(sub_source_file);
+                    }
                 }
 
                 match document.print_code(entrypoint, language, settings) {
@@ -797,9 +808,12 @@ fn compile_reverse(
     let mut entries = parser.get_entry_points(&document, language);
 
     let file_name_without_ext = file_name.with_extension("");
-    entries.insert(entrypoint, &file_name_without_ext);
+    entries.insert(
+        entrypoint,
+        (&file_name_without_ext, Some(PathBuf::from(file_name))),
+    );
 
-    for (_entrypoint, sub_file_name) in entries {
+    for (_entrypoint, (sub_file_name, _sub_source_file)) in entries {
         match code_dir {
             Some(code_dir) => {
                 let mut file_path = code_dir.to_owned();
@@ -808,15 +822,7 @@ fn compile_reverse(
                     file_path.set_extension(language);
                 }
 
-                if track_code_files.contains(&file_path) {
-                    return Err(format!(
-                        "Multiple locations point to code file {}",
-                        file_path.display()
-                    )
-                    .into());
-                } else {
-                    track_code_files.insert(file_path);
-                }
+                track_code_files.insert(file_path);
             }
             None => eprintln!("WARNING: Missing output location for code, skipping code output."),
         }

--- a/src/parser/md.rs
+++ b/src/parser/md.rs
@@ -428,13 +428,19 @@ Please comment out option `comments_as_aside` until the next version, and rename
         &self,
         doc: &'a Document,
         language: Option<&'a str>,
-    ) -> HashMap<Option<&'a str>, &'a Path> {
+    ) -> HashMap<Option<&'a str>, (&'a Path, Option<PathBuf>)> {
         let mut entries = HashMap::new();
         let pref = &self.file_prefix;
         for block in doc.code_blocks(language) {
             if let Some(name) = block.name.as_deref() {
                 if let Some(rest) = name.strip_prefix(pref) {
-                    entries.insert(Some(name), Path::new(rest));
+                    entries.insert(
+                        Some(name),
+                        (
+                            Path::new(rest),
+                            block.source_file.as_ref().map(|file| file.into()),
+                        ),
+                    );
                 }
             }
         }


### PR DESCRIPTION
With this in the `toml`, it was possible to write multiple times to the same code file (i.e. once per entry):

```
files = ["file-1.md", "file-2.md"]
```

Further modified to only prevent multiple writes if they really come from different source files (respecting transclusion sources)