### PR TITLE
Added support for CRLF line endings through option in Yarner.toml

### DIFF
--- a/guide/src/config-parser.md
+++ b/guide/src/config-parser.md
@@ -26,6 +26,8 @@ link_prefix = "@"
 
 file_prefix = "file:"
 hidden_prefix = "hidden:"
+
+# crlf_newline = false
 ```
 
 ## Options
@@ -40,3 +42,4 @@ hidden_prefix = "hidden:"
 | `link_prefix`                             | Prefix for links to make Yarner include the linked file in the build process. E.g. `@[Linked file](linked.md)`                                                         |
 | `file_prefix`                             | Prefix to treat block names as target file specifiers. E.g. `//- file:main.rs`                                                                                         |
 | `hidden_prefix`                           | Prefix to hide a code block in documentation output. E.g. `//- hidden:Secret code block`                                                                               |
+| `crlf_newline`                            | Whether to use Windows line endings (`CRLF`) or not. Optional. Uses system line endings if not provided                                                                |

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -103,7 +103,8 @@ fn compile(
                         }
                     }
 
-                    let code = print::print_code(&code_blocks, entry_blocks, settings)?;
+                    let code =
+                        print::print_code(&code_blocks, entry_blocks, &config.parser, settings)?;
                     println!("  Writing file {}", file_path.display());
                     fs::create_dir_all(file_path.parent().unwrap())?;
                     let mut code_file = File::create(file_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,9 @@ pub struct ParserSettings {
     pub file_prefix: String,
     /// Name prefix for code blocks not shown in the docs.
     pub hidden_prefix: String,
+    /// Use CRLF / Windows line endings for all output.
+    #[serde(default)]
+    pub crlf_newline: bool,
 }
 
 impl ParserSettings {
@@ -89,6 +92,14 @@ impl ParserSettings {
 Please comment out option `comments_as_aside` until the next version, and rename `comment_start` to `block_name_prefix`"#.to_string())
         } else {
             Ok(())
+        }
+    }
+
+    pub fn newline(&self) -> &str {
+        if self.crlf_newline {
+            "\r\n"
+        } else {
+            "\n"
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,6 +233,33 @@ mod tests {
     const CONFIG: &str = include_str!("create/Yarner.toml");
 
     #[test]
+    fn newline_windows() {
+        let mut config = toml::from_str::<Config>(CONFIG).unwrap();
+        config.parser.crlf_newline = Some(true);
+        assert_eq!(config.parser.newline(), "\r\n");
+    }
+
+    #[test]
+    fn newline_unix() {
+        let mut config = toml::from_str::<Config>(CONFIG).unwrap();
+        config.parser.crlf_newline = Some(false);
+        assert_eq!(config.parser.newline(), "\n");
+    }
+
+    #[test]
+    fn newline_system() {
+        let config = toml::from_str::<Config>(CONFIG).unwrap();
+
+        let expected = if cfg!(target_os = "windows") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+
+        assert_eq!(config.parser.newline(), expected);
+    }
+
+    #[test]
     fn config_template() {
         let config = toml::from_str::<Config>(CONFIG).unwrap();
         config.check().unwrap();

--- a/src/create/Yarner.toml
+++ b/src/create/Yarner.toml
@@ -15,8 +15,6 @@ link_prefix = "@"
 file_prefix = "file:"
 hidden_prefix = "hidden:"
 
-crlf_newline = false
-
 [paths]
 root = "."
 code = "code/"

--- a/src/create/Yarner.toml
+++ b/src/create/Yarner.toml
@@ -15,6 +15,8 @@ link_prefix = "@"
 file_prefix = "file:"
 hidden_prefix = "hidden:"
 
+crlf_newline = false
+
 [paths]
 root = "."
 code = "code/"

--- a/src/document.rs
+++ b/src/document.rs
@@ -324,7 +324,7 @@ impl Line {
                     if !clean {
                         write!(
                             result,
-                            "{}{} {}{}{}{}{}{}{}",
+                            "{}{} {}{}{}{}{}{}{}{}",
                             &self.indent,
                             comment_start,
                             if idx == 0 { &block_start } else { &block_next },
@@ -334,9 +334,9 @@ impl Line {
                             block_name_sep,
                             idx,
                             comment_end,
+                            newline,
                         )
                         .unwrap();
-                        write!(result, "{}", newline).unwrap();
                     }
 
                     let code = block.compile_with(code_blocks, settings, newline)?;
@@ -344,16 +344,14 @@ impl Line {
                         if blank_lines && line.trim().is_empty() {
                             write!(result, "{}", newline).unwrap();
                         } else {
-                            write!(result, "{}", self.indent).unwrap();
-                            write!(result, "{}", line).unwrap();
-                            write!(result, "{}", newline).unwrap();
+                            write!(result, "{}{}{}", self.indent, line, newline).unwrap();
                         }
                     }
 
                     if !clean && idx == blocks.len() - 1 {
                         write!(
                             result,
-                            "{}{} {}{}{}{}{}{}{}",
+                            "{}{} {}{}{}{}{}{}{}{}",
                             &self.indent,
                             comment_start,
                             &block_end,
@@ -363,9 +361,9 @@ impl Line {
                             block_name_sep,
                             idx,
                             comment_end,
+                            newline,
                         )
                         .unwrap();
-                        write!(result, "{}", newline).unwrap();
                     }
                 }
                 for _ in 0..newline.len() {

--- a/src/document.rs
+++ b/src/document.rs
@@ -3,7 +3,7 @@ use crate::config::{LanguageSettings, ParserSettings};
 use crate::util::TryCollectExt;
 
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
 /// A representation of a `Document` of literate code
@@ -142,12 +142,6 @@ impl TextBlock {
     }
 }
 
-impl Display for TextBlock {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.text.join("\n"))
-    }
-}
-
 /// A `Transclusion` is a reference to another file that should be pulled into the source
 #[derive(Debug, PartialEq, Clone)]
 pub struct Transclusion {
@@ -240,12 +234,13 @@ impl CodeBlock {
         &self,
         code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
         settings: Option<&LanguageSettings>,
+        newline: &str,
     ) -> Result<String, CompileError> {
         self.source
             .iter()
-            .map(|line| line.compile_with(code_blocks, settings))
+            .map(|line| line.compile_with(code_blocks, settings, newline))
             .try_collect()
-            .map(|lines| lines.join("\n"))
+            .map(|lines| lines.join(newline))
             .map_err(CompileError::Multi)
     }
 }
@@ -278,6 +273,7 @@ impl Line {
         &self,
         code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
         settings: Option<&LanguageSettings>,
+        newline: &str,
     ) -> Result<String, CompileError> {
         let block_labels = settings.and_then(|s| s.block_labels.as_ref());
         let comment_start = block_labels
@@ -326,7 +322,7 @@ impl Line {
                     };
 
                     if !clean {
-                        writeln!(
+                        write!(
                             result,
                             "{}{} {}{}{}{}{}{}{}",
                             &self.indent,
@@ -340,20 +336,22 @@ impl Line {
                             comment_end,
                         )
                         .unwrap();
+                        write!(result, "{}", newline).unwrap();
                     }
 
-                    let code = block.compile_with(code_blocks, settings)?;
+                    let code = block.compile_with(code_blocks, settings, newline)?;
                     for line in code.lines() {
                         if blank_lines && line.trim().is_empty() {
-                            writeln!(result).unwrap();
+                            write!(result, "{}", newline).unwrap();
                         } else {
                             write!(result, "{}", self.indent).unwrap();
-                            writeln!(result, "{}", line).unwrap();
+                            write!(result, "{}", line).unwrap();
+                            write!(result, "{}", newline).unwrap();
                         }
                     }
 
                     if !clean && idx == blocks.len() - 1 {
-                        writeln!(
+                        write!(
                             result,
                             "{}{} {}{}{}{}{}{}{}",
                             &self.indent,
@@ -367,9 +365,12 @@ impl Line {
                             comment_end,
                         )
                         .unwrap();
+                        write!(result, "{}", newline).unwrap();
                     }
                 }
-                result.pop();
+                for _ in 0..newline.len() {
+                    result.pop();
+                }
                 Ok(result)
             }
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -719,6 +719,7 @@ text
             ),
             file_prefix: "file:".to_string(),
             hidden_prefix: "hidden:".to_string(),
+            crlf_newline: false,
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -719,7 +719,7 @@ text
             ),
             file_prefix: "file:".to_string(),
             hidden_prefix: "hidden:".to_string(),
-            crlf_newline: false,
+            crlf_newline: Some(false),
         }
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -303,7 +303,8 @@ mod tests {
 
     #[test]
     fn print_code_block() {
-        let config = toml::from_str::<Config>(include_str!("create/Yarner.toml")).unwrap();
+        let mut config = toml::from_str::<Config>(include_str!("create/Yarner.toml")).unwrap();
+        config.parser.crlf_newline = Some(false);
 
         let code = CodeBlock {
             indent: "".to_string(),


### PR DESCRIPTION
Line endings can be controlled via bool option `crlf_newline` in section `[parser]` of `Yarner.toml`.

~~Not really an optimal solution for projects used on different systems.~~

Made `crlf_newline` optional, use system newline if not provided.

Fixes #119