### PR TITLE
[Design] Re-structuring print module

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -56,7 +56,7 @@ fn compile(
 
     match &config.paths.docs {
         Some(doc_dir) => {
-            let documentation = print::print_docs(document, &config.parser);
+            let documentation = print::docs::print_docs(document, &config.parser);
             let mut file_path = doc_dir.to_owned();
             file_path.push(file_name);
             fs::create_dir_all(file_path.parent().unwrap()).unwrap();
@@ -103,7 +103,7 @@ fn compile(
                         }
                     }
 
-                    let code = print::print_code(
+                    let code = print::code::print_code(
                         &code_blocks,
                         entry_blocks,
                         settings,

--- a/src/compile_reverse.rs
+++ b/src/compile_reverse.rs
@@ -1,14 +1,7 @@
-use std::collections::{
-    hash_map::Entry::{Occupied, Vacant},
-    HashMap, HashSet,
-};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use crate::{
-    code, code::RevCodeBlock, config::Config, document::Document, files, parse, util::Fallible,
-};
-
-type BlockKey = (PathBuf, Option<String>, usize);
+use crate::{config::Config, document::Document, files, parse, util::Fallible};
 
 pub fn compile_all(
     config: &Config,
@@ -48,48 +41,6 @@ pub fn compile_all(
     }
 
     Ok(())
-}
-
-/// Collects all code blocks from the given code files
-pub fn collect_code_blocks(
-    code_files: &HashSet<PathBuf>,
-    config: &Config,
-) -> Fallible<HashMap<BlockKey, RevCodeBlock>> {
-    let mut code_blocks: HashMap<BlockKey, RevCodeBlock> = HashMap::new();
-
-    if !config.language.is_empty() {
-        for file in code_files {
-            let language = file.extension().and_then(|s| s.to_str());
-            if let Some(language) = language {
-                if let Some(labels) = config
-                    .language
-                    .get(language)
-                    .and_then(|lang| lang.block_labels.as_ref())
-                {
-                    let source = files::read_file_string(&file)?;
-                    let blocks = code::parse(&source, &config.parser, labels)?;
-
-                    for block in blocks.into_iter() {
-                        let path = PathBuf::from(&block.file);
-                        match code_blocks.entry((path, block.name.clone(), block.index)) {
-                            Occupied(entry) => {
-                                if entry.get().lines != block.lines {
-                                    return Err(format!("Reverse mode impossible due to multiple, differing occurrences of a code block: {} # {} # {}", &block.file, &block.name.unwrap_or_else(|| "".to_string()), block.index).into());
-                                } else {
-                                    eprintln!("  WARNING: multiple occurrences of a code block: {} # {} # {}", &block.file, &block.name.unwrap_or_else(|| "".to_string()), block.index)
-                                }
-                            }
-                            Vacant(entry) => {
-                                entry.insert(block);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(code_blocks)
 }
 
 fn compile(

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,7 @@ fn process_inputs_reverse(
             .collect();
 
         if !blocks.is_empty() {
-            let print = print::print_reverse(&doc, &config.parser, &blocks);
+            let print = print::docs::print_reverse(&doc, &config.parser, &blocks);
             println!("  Writing back to file {}", path.display());
             let mut file = File::create(path).unwrap();
             write!(file, "{}", print).unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn process_inputs_reverse(
         .into());
     }
 
-    let code_blocks = compile_reverse::collect_code_blocks(&code_files, &config)?;
+    let code_blocks = code::collect_code_blocks(&code_files, &config)?;
     for (path, doc) in documents {
         let blocks: HashMap<_, _> = code_blocks
             .iter()

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,30 +1,78 @@
-use crate::code::RevCodeBlock;
-use crate::config::{LanguageSettings, ParserSettings};
-use crate::document::{CodeBlock, CompileError, Document, Line, Node, Source, Transclusion};
-use std::collections::HashMap;
-use std::fmt::Write;
+pub mod docs {
+    use crate::code::RevCodeBlock;
+    use crate::config::ParserSettings;
+    use crate::document::{CodeBlock, Document, Line, Node, Source, Transclusion};
+    use std::collections::HashMap;
+    use std::fmt::Write;
 
-/// Formats this `Document` as a string containing the documentation file contents
-pub fn print_docs(document: &Document, settings: &ParserSettings) -> String {
-    let mut output = String::new();
-    for node in &document.nodes {
-        match node {
-            Node::Transclusion(transclusion) => {
-                print_transclusion(transclusion, document.newline(), &mut output)
+    /// Formats this `Document` as a string containing the documentation file contents
+    pub fn print_docs(document: &Document, settings: &ParserSettings) -> String {
+        let mut output = String::new();
+        for node in &document.nodes {
+            match node {
+                Node::Transclusion(transclusion) => {
+                    print_transclusion(transclusion, document.newline(), &mut output)
+                }
+                Node::Text(text_block) => {
+                    write!(
+                        output,
+                        "{}{}",
+                        text_block.lines().join(&document.newline()),
+                        document.newline()
+                    )
+                    .unwrap();
+                }
+                Node::Code(code_block) => {
+                    if !code_block.hidden {
+                        print_code_block(
+                            code_block,
+                            settings,
+                            &code_block.indent,
+                            document.newline(),
+                            &mut output,
+                        );
+                    }
+                }
             }
-            Node::Text(text_block) => {
-                write!(
-                    output,
-                    "{}{}",
-                    text_block.lines().join(&document.newline()),
-                    document.newline()
-                )
-                .unwrap();
-            }
-            Node::Code(code_block) => {
-                if !code_block.hidden {
-                    print_code_block(
+        }
+        output
+    }
+
+    /// Formats this `Document` as the original source, potentially replacing code blocks
+    pub fn print_reverse(
+        document: &Document,
+        settings: &ParserSettings,
+        code_blocks: &HashMap<(&Option<String>, &usize), &RevCodeBlock>,
+    ) -> String {
+        let mut block_count: HashMap<&Option<String>, usize> = HashMap::new();
+
+        let mut output = String::new();
+        for node in &document.nodes {
+            match node {
+                Node::Transclusion(transclusion) => {
+                    print_transclusion_reverse(transclusion, document.newline(), &mut output)
+                }
+                Node::Text(text_block) => {
+                    write!(
+                        output,
+                        "{}{}",
+                        text_block.lines().join(&document.newline()),
+                        document.newline()
+                    )
+                    .unwrap();
+                }
+                Node::Code(code_block) => {
+                    let index = {
+                        let count = block_count.entry(&code_block.name).or_default();
+                        *count += 1;
+                        *count - 1
+                    };
+
+                    let alt_block = code_blocks.get(&(&code_block.name, &index));
+
+                    print_code_block_reverse(
                         code_block,
+                        alt_block.copied(),
                         settings,
                         &code_block.indent,
                         document.newline(),
@@ -33,305 +81,425 @@ pub fn print_docs(document: &Document, settings: &ParserSettings) -> String {
                 }
             }
         }
-    }
-    output
-}
-
-/// Formats this `Document` as a string containing the compiled code
-pub fn print_code(
-    code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
-    entry_blocks: &[&CodeBlock],
-    settings: Option<&LanguageSettings>,
-    newline: &str,
-) -> Result<String, CompileError> {
-    let block_labels = settings.and_then(|s| s.block_labels.as_ref());
-    let comment_start = block_labels
-        .map(|l| l.comment_start.as_str())
-        .unwrap_or_default();
-    let comment_end = block_labels
-        .and_then(|l| l.comment_end.as_deref())
-        .unwrap_or_default();
-    let block_start = block_labels
-        .map(|l| l.block_start.as_str())
-        .unwrap_or_default();
-    let block_end = block_labels
-        .map(|l| l.block_end.as_str())
-        .unwrap_or_default();
-    let block_next = block_labels
-        .map(|l| l.block_next.as_str())
-        .unwrap_or_default();
-    let block_name_sep = '#';
-
-    let clean = settings.map_or(true, |set| set.clean_code || set.block_labels.is_none());
-
-    let mut result = String::new();
-    let mut block_count: HashMap<&Option<String>, usize> = HashMap::new();
-    for (idx, block) in entry_blocks.iter().enumerate() {
-        let index = {
-            let count = block_count.entry(&block.name).or_default();
-            *count += 1;
-            *count - 1
-        };
-
-        let path = block.source_file.to_owned().unwrap_or_default();
-        let name = if block.is_unnamed {
-            ""
-        } else {
-            block.name.as_deref().unwrap_or("")
-        };
-
-        if !clean {
-            let sep = if idx == 0 || block.name != entry_blocks[idx - 1].name {
-                &block_start
-            } else {
-                &block_next
-            };
-            write!(
-                result,
-                "{} {}{}{}{}{}{}{}{}",
-                comment_start,
-                sep,
-                path,
-                block_name_sep,
-                name,
-                block_name_sep,
-                index,
-                comment_end,
-                newline,
-            )
-            .unwrap();
-        }
-        write!(
-            result,
-            "{}{}",
-            block.compile_with(&code_blocks, settings, newline)?,
-            newline,
-        )
-        .unwrap();
-
-        if !clean && (idx == entry_blocks.len() - 1 || block.name != entry_blocks[idx + 1].name) {
-            write!(
-                result,
-                "{} {}{}{}{}{}{}{}",
-                comment_start,
-                block_end,
-                path,
-                block_name_sep,
-                name,
-                block_name_sep,
-                index,
-                comment_end,
-            )
-            .unwrap();
-        }
+        output
     }
 
-    if settings.map(|s| s.eof_newline).unwrap_or(true) && !result.ends_with(newline) {
-        write!(result, "{}", newline).unwrap();
-    }
-    Ok(result)
-}
-
-/// Formats this `Document` as the original source, potentially replacing code blocks
-pub fn print_reverse(
-    document: &Document,
-    settings: &ParserSettings,
-    code_blocks: &HashMap<(&Option<String>, &usize), &RevCodeBlock>,
-) -> String {
-    let mut block_count: HashMap<&Option<String>, usize> = HashMap::new();
-
-    let mut output = String::new();
-    for node in &document.nodes {
-        match node {
-            Node::Transclusion(transclusion) => {
-                print_transclusion_reverse(transclusion, document.newline(), &mut output)
-            }
-            Node::Text(text_block) => {
-                write!(
-                    output,
-                    "{}{}",
-                    text_block.lines().join(&document.newline()),
-                    document.newline()
-                )
-                .unwrap();
-            }
-            Node::Code(code_block) => {
-                let index = {
-                    let count = block_count.entry(&code_block.name).or_default();
-                    *count += 1;
-                    *count - 1
-                };
-
-                let alt_block = code_blocks.get(&(&code_block.name, &index));
-
-                print_code_block_reverse(
-                    code_block,
-                    alt_block.copied(),
-                    settings,
-                    &code_block.indent,
-                    document.newline(),
-                    &mut output,
-                );
-            }
-        }
-    }
-    output
-}
-
-pub fn print_transclusion(transclusion: &Transclusion, newline: &str, write: &mut impl Write) {
-    write!(
-        write,
-        "**WARNING!** Missed/skipped transclusion: {}{}",
-        transclusion.file().to_str().unwrap(),
-        newline
-    )
-    .unwrap();
-}
-
-pub fn print_transclusion_reverse(
-    transclusion: &Transclusion,
-    newline: &str,
-    write: &mut impl Write,
-) {
-    write!(write, "{}{}", transclusion.original(), newline).unwrap();
-}
-
-pub fn print_code_block(
-    block: &CodeBlock,
-    settings: &ParserSettings,
-    indent: &str,
-    newline: &str,
-    write: &mut impl Write,
-) {
-    let fence_sequence = if block.alternative {
-        &settings.fence_sequence_alt
-    } else {
-        &settings.fence_sequence
-    };
-    write!(write, "{}{}", indent, fence_sequence).unwrap();
-    if let Some(language) = &block.language {
-        write!(write, "{}", language).unwrap();
-    }
-    write!(write, "{}", newline).unwrap();
-
-    if let Some(name) = &block.name {
+    pub fn print_transclusion(transclusion: &Transclusion, newline: &str, write: &mut impl Write) {
         write!(
             write,
-            "{}{} {}{}",
-            indent, settings.block_name_prefix, name, newline,
-        )
-        .unwrap();
-    }
-
-    let mut comments = vec![];
-    let line_offset = block.line_number().unwrap_or(0);
-    for line in &block.source {
-        print_line(
-            &line,
-            settings,
-            !settings.comments_as_aside,
-            indent,
-            newline,
-            write,
-        );
-        if settings.comments_as_aside {
-            if let Some(comment) = &line.comment {
-                comments.push((line.line_number - line_offset, comment));
-            }
-        }
-    }
-
-    write!(write, "{}{}{}", indent, fence_sequence, newline).unwrap();
-
-    for (line, comment) in comments {
-        write!(
-            write,
-            "<aside class=\"comment\" data-line=\"{}\">{}</aside>{}",
-            line,
-            comment.trim(),
+            "**WARNING!** Missed/skipped transclusion: {}{}",
+            transclusion.file().to_str().unwrap(),
             newline
         )
         .unwrap();
     }
-}
 
-pub fn print_code_block_reverse(
-    block: &CodeBlock,
-    alternative: Option<&RevCodeBlock>,
-    settings: &ParserSettings,
-    indent: &str,
-    newline: &str,
-    write: &mut impl Write,
-) {
-    let fence_sequence = if block.alternative {
-        &settings.fence_sequence_alt
-    } else {
-        &settings.fence_sequence
-    };
-    write!(write, "{}{}", indent, fence_sequence).unwrap();
-    if let Some(language) = &block.language {
-        write!(write, "{}", language).unwrap();
-    }
-    write!(write, "{}", newline).unwrap();
-
-    if let Some(name) = &block.name {
-        write!(write, "{}{} ", indent, settings.block_name_prefix).unwrap();
-        if block.hidden {
-            write!(write, "{}", settings.hidden_prefix).unwrap();
-        }
-        write!(write, "{}{}", name, newline).unwrap();
+    pub fn print_transclusion_reverse(
+        transclusion: &Transclusion,
+        newline: &str,
+        write: &mut impl Write,
+    ) {
+        write!(write, "{}{}", transclusion.original(), newline).unwrap();
     }
 
-    if let Some(alt) = alternative {
-        for line in &alt.lines {
-            if line.is_empty() {
-                write!(write, "{}", newline).unwrap();
-            } else {
-                write!(write, "{}{}{}", indent, line, newline).unwrap();
-            }
+    pub fn print_code_block(
+        block: &CodeBlock,
+        settings: &ParserSettings,
+        indent: &str,
+        newline: &str,
+        write: &mut impl Write,
+    ) {
+        let fence_sequence = if block.alternative {
+            &settings.fence_sequence_alt
+        } else {
+            &settings.fence_sequence
+        };
+        write!(write, "{}{}", indent, fence_sequence).unwrap();
+        if let Some(language) = &block.language {
+            write!(write, "{}", language).unwrap();
         }
-    } else {
+        write!(write, "{}", newline).unwrap();
+
+        if let Some(name) = &block.name {
+            write!(
+                write,
+                "{}{} {}{}",
+                indent, settings.block_name_prefix, name, newline,
+            )
+            .unwrap();
+        }
+
+        let mut comments = vec![];
+        let line_offset = block.line_number().unwrap_or(0);
         for line in &block.source {
-            print_line(&line, settings, true, indent, newline, write);
+            print_line(
+                &line,
+                settings,
+                !settings.comments_as_aside,
+                indent,
+                newline,
+                write,
+            );
+            if settings.comments_as_aside {
+                if let Some(comment) = &line.comment {
+                    comments.push((line.line_number - line_offset, comment));
+                }
+            }
+        }
+
+        write!(write, "{}{}{}", indent, fence_sequence, newline).unwrap();
+
+        for (line, comment) in comments {
+            write!(
+                write,
+                "<aside class=\"comment\" data-line=\"{}\">{}</aside>{}",
+                line,
+                comment.trim(),
+                newline
+            )
+            .unwrap();
         }
     }
-    write!(write, "{}{}", fence_sequence, newline).unwrap();
+
+    pub fn print_code_block_reverse(
+        block: &CodeBlock,
+        alternative: Option<&RevCodeBlock>,
+        settings: &ParserSettings,
+        indent: &str,
+        newline: &str,
+        write: &mut impl Write,
+    ) {
+        let fence_sequence = if block.alternative {
+            &settings.fence_sequence_alt
+        } else {
+            &settings.fence_sequence
+        };
+        write!(write, "{}{}", indent, fence_sequence).unwrap();
+        if let Some(language) = &block.language {
+            write!(write, "{}", language).unwrap();
+        }
+        write!(write, "{}", newline).unwrap();
+
+        if let Some(name) = &block.name {
+            write!(write, "{}{} ", indent, settings.block_name_prefix).unwrap();
+            if block.hidden {
+                write!(write, "{}", settings.hidden_prefix).unwrap();
+            }
+            write!(write, "{}{}", name, newline).unwrap();
+        }
+
+        if let Some(alt) = alternative {
+            for line in &alt.lines {
+                if line.is_empty() {
+                    write!(write, "{}", newline).unwrap();
+                } else {
+                    write!(write, "{}{}{}", indent, line, newline).unwrap();
+                }
+            }
+        } else {
+            for line in &block.source {
+                print_line(&line, settings, true, indent, newline, write);
+            }
+        }
+        write!(write, "{}{}", fence_sequence, newline).unwrap();
+    }
+
+    /// Prints a line of a code block
+    pub fn print_line(
+        line: &Line,
+        settings: &ParserSettings,
+        print_comments: bool,
+        indent: &str,
+        newline: &str,
+        write: &mut impl Write,
+    ) {
+        write!(write, "{}{}", indent, line.indent).unwrap();
+        match &line.source {
+            Source::Macro(name) => {
+                write!(write, "{}", settings.macro_start).unwrap();
+                if !settings.macro_start.ends_with(' ') {
+                    write!(write, " ").unwrap();
+                }
+                write!(write, "{}{}", name, settings.macro_end).unwrap();
+            }
+            Source::Source(string) => {
+                write!(write, "{}", string).unwrap();
+            }
+        }
+        if print_comments {
+            if let Some(comment) = &line.comment {
+                write!(write, "{}{}", settings.block_name_prefix, comment).unwrap();
+            }
+        }
+        write!(write, "{}", newline).unwrap();
+    }
 }
 
-/// Prints a line of a code block
-pub fn print_line(
-    line: &Line,
-    settings: &ParserSettings,
-    print_comments: bool,
-    indent: &str,
-    newline: &str,
-    write: &mut impl Write,
-) {
-    write!(write, "{}{}", indent, line.indent).unwrap();
-    match &line.source {
-        Source::Macro(name) => {
-            write!(write, "{}", settings.macro_start).unwrap();
-            if !settings.macro_start.ends_with(' ') {
-                write!(write, " ").unwrap();
+pub mod code {
+    use crate::config::LanguageSettings;
+    use crate::document::{CodeBlock, Line, Source};
+    use crate::util::TryCollectExt;
+    use std::collections::HashMap;
+    use std::fmt::Write;
+
+    /// Formats this `Document` as a string containing the compiled code
+    pub fn print_code(
+        code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
+        entry_blocks: &[&CodeBlock],
+        settings: Option<&LanguageSettings>,
+        newline: &str,
+    ) -> Result<String, CompileError> {
+        let block_labels = settings.and_then(|s| s.block_labels.as_ref());
+        let comment_start = block_labels
+            .map(|l| l.comment_start.as_str())
+            .unwrap_or_default();
+        let comment_end = block_labels
+            .and_then(|l| l.comment_end.as_deref())
+            .unwrap_or_default();
+        let block_start = block_labels
+            .map(|l| l.block_start.as_str())
+            .unwrap_or_default();
+        let block_end = block_labels
+            .map(|l| l.block_end.as_str())
+            .unwrap_or_default();
+        let block_next = block_labels
+            .map(|l| l.block_next.as_str())
+            .unwrap_or_default();
+        let block_name_sep = '#';
+
+        let clean = settings.map_or(true, |set| set.clean_code || set.block_labels.is_none());
+
+        let mut result = String::new();
+        let mut block_count: HashMap<&Option<String>, usize> = HashMap::new();
+        for (idx, block) in entry_blocks.iter().enumerate() {
+            let index = {
+                let count = block_count.entry(&block.name).or_default();
+                *count += 1;
+                *count - 1
+            };
+
+            let path = block.source_file.to_owned().unwrap_or_default();
+            let name = if block.is_unnamed {
+                ""
+            } else {
+                block.name.as_deref().unwrap_or("")
+            };
+
+            if !clean {
+                let sep = if idx == 0 || block.name != entry_blocks[idx - 1].name {
+                    &block_start
+                } else {
+                    &block_next
+                };
+                write!(
+                    result,
+                    "{} {}{}{}{}{}{}{}{}",
+                    comment_start,
+                    sep,
+                    path,
+                    block_name_sep,
+                    name,
+                    block_name_sep,
+                    index,
+                    comment_end,
+                    newline,
+                )
+                .unwrap();
             }
-            write!(write, "{}{}", name, settings.macro_end).unwrap();
+            write!(
+                result,
+                "{}{}",
+                compile_code_block(block, &code_blocks, settings, newline)?,
+                newline,
+            )
+            .unwrap();
+
+            if !clean && (idx == entry_blocks.len() - 1 || block.name != entry_blocks[idx + 1].name)
+            {
+                write!(
+                    result,
+                    "{} {}{}{}{}{}{}{}",
+                    comment_start,
+                    block_end,
+                    path,
+                    block_name_sep,
+                    name,
+                    block_name_sep,
+                    index,
+                    comment_end,
+                )
+                .unwrap();
+            }
         }
-        Source::Source(string) => {
-            write!(write, "{}", string).unwrap();
+
+        if settings.map(|s| s.eof_newline).unwrap_or(true) && !result.ends_with(newline) {
+            write!(result, "{}", newline).unwrap();
+        }
+        Ok(result)
+    }
+
+    fn compile_code_block(
+        block: &CodeBlock,
+        code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
+        settings: Option<&LanguageSettings>,
+        newline: &str,
+    ) -> Result<String, CompileError> {
+        block
+            .source
+            .iter()
+            .map(|line| compile_line(&line, code_blocks, settings, newline))
+            .try_collect()
+            .map(|lines| lines.join(newline))
+            .map_err(CompileError::Multi)
+    }
+
+    fn compile_line(
+        line: &Line,
+        code_blocks: &HashMap<Option<&str>, Vec<&CodeBlock>>,
+        settings: Option<&LanguageSettings>,
+        newline: &str,
+    ) -> Result<String, CompileError> {
+        let block_labels = settings.and_then(|s| s.block_labels.as_ref());
+        let comment_start = block_labels
+            .map(|l| l.comment_start.as_str())
+            .unwrap_or_default();
+        let comment_end = block_labels
+            .and_then(|l| l.comment_end.as_deref())
+            .unwrap_or_default();
+        let block_start = block_labels
+            .map(|l| l.block_start.as_str())
+            .unwrap_or_default();
+        let block_end = block_labels
+            .map(|l| l.block_end.as_str())
+            .unwrap_or_default();
+        let block_next = block_labels.map(|l| l.block_next.as_str()).unwrap_or("");
+        let block_name_sep = '#';
+
+        let clean = if let Some(s) = settings {
+            s.clean_code || s.block_labels.is_none()
+        } else {
+            true
+        };
+
+        let blank_lines = settings.map(|s| s.clear_blank_lines).unwrap_or(true);
+        match &line.source {
+            Source::Source(string) => {
+                if blank_lines && string.trim().is_empty() {
+                    Ok("".to_string())
+                } else {
+                    Ok(format!("{}{}", line.indent, string))
+                }
+            }
+            Source::Macro(name) => {
+                let blocks = code_blocks.get(&Some(name)).ok_or(CompileError::Single {
+                    line_number: line.line_number,
+                    kind: CompileErrorKind::UnknownMacro(name.to_string()),
+                })?;
+
+                let mut result = String::new();
+                for (idx, block) in blocks.iter().enumerate() {
+                    let path = block.source_file.to_owned().unwrap_or_default();
+                    let name = if block.is_unnamed {
+                        ""
+                    } else {
+                        block.name.as_ref().map(|n| &n[..]).unwrap_or("")
+                    };
+
+                    if !clean {
+                        write!(
+                            result,
+                            "{}{} {}{}{}{}{}{}{}{}",
+                            &line.indent,
+                            comment_start,
+                            if idx == 0 { &block_start } else { &block_next },
+                            path,
+                            block_name_sep,
+                            name,
+                            block_name_sep,
+                            idx,
+                            comment_end,
+                            newline,
+                        )
+                        .unwrap();
+                    }
+
+                    let code = compile_code_block(block, code_blocks, settings, newline)?;
+                    for ln in code.lines() {
+                        if blank_lines && ln.trim().is_empty() {
+                            write!(result, "{}", newline).unwrap();
+                        } else {
+                            write!(result, "{}{}{}", line.indent, ln, newline).unwrap();
+                        }
+                    }
+
+                    if !clean && idx == blocks.len() - 1 {
+                        write!(
+                            result,
+                            "{}{} {}{}{}{}{}{}{}{}",
+                            &line.indent,
+                            comment_start,
+                            &block_end,
+                            path,
+                            block_name_sep,
+                            name,
+                            block_name_sep,
+                            idx,
+                            comment_end,
+                            newline,
+                        )
+                        .unwrap();
+                    }
+                }
+                for _ in 0..newline.len() {
+                    result.pop();
+                }
+                Ok(result)
+            }
         }
     }
-    if print_comments {
-        if let Some(comment) = &line.comment {
-            write!(write, "{}{}", settings.block_name_prefix, comment).unwrap();
+
+    /// Problems encountered while compiling the document
+    #[derive(Debug)]
+    pub enum CompileErrorKind {
+        /// An unknown macro name was encountered
+        UnknownMacro(String),
+    }
+
+    /// Errors that were encountered while compiling the document
+    #[derive(Debug)]
+    pub enum CompileError {
+        #[doc(hidden)]
+        Multi(Vec<CompileError>),
+        #[doc(hidden)]
+        Single {
+            line_number: usize,
+            kind: CompileErrorKind,
+        },
+    }
+
+    impl std::fmt::Display for CompileError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                CompileError::Multi(errors) => {
+                    for error in errors {
+                        writeln!(f, "{}", error)?;
+                    }
+                    Ok(())
+                }
+                CompileError::Single { line_number, kind } => {
+                    writeln!(f, "{:?} (line {})", kind, line_number)
+                }
+            }
         }
     }
-    write!(write, "{}", newline).unwrap();
+
+    impl std::error::Error for CompileError {}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::config::Config;
+    use crate::document::{CodeBlock, Line, Source};
 
     #[test]
     fn print_code_block() {
@@ -362,7 +530,7 @@ mod tests {
         };
 
         let mut out = String::new();
-        super::print_code_block(&code, &config.parser, "", "\n", &mut out);
+        super::docs::print_code_block(&code, &config.parser, "", "\n", &mut out);
 
         assert_eq!(
             out,


### PR DESCRIPTION
* Split module `print` into sub-modules for docs and code
* Move remaining print-related functions from `document` to `print` to bring `document` closer to a data-only module
* Move function `collect_code_blocks` from `compile_reverse` to `code`

