### PR TITLE
JSON pre-processors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "pathdiff",
  "regex",
  "serde",
+ "serde_json",
  "toml",
  "yarner-lib",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ codegen-units = 1
 yarner-lib = { path = "yarner-lib" }
 serde = { version = "1.0", features = ["derive"] }
 toml = { version = "0.5", features = ["preserve_order"] }
+serde_json = "1.0"
 regex = "1.4"
 path-clean = "0.1"
 pathdiff = "0.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use regex::Regex;
 use serde::{de::Error as _, Deserialize, Deserializer};
 
 use crate::{files, util::Fallible};
+use toml::value::Table;
 
 pub const LINK_PATTERN: &str = r"\[([^\[\]]*)\]\((.*?)\)";
 pub static LINK_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(LINK_PATTERN).unwrap());
@@ -25,6 +26,9 @@ pub struct Config {
     /// Programming language specific settings
     #[serde(default)]
     pub language: HashMap<String, LanguageSettings>,
+    /// TOML table of settings for pre-processors
+    #[serde(default)]
+    pub preprocessor: Table,
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod create;
 mod files;
 mod lock;
 mod parse;
+mod preprocess;
 mod print;
 mod util;
 
@@ -356,10 +357,10 @@ fn process_inputs_forward(
         .into());
     }
 
+    let original_documents = documents.keys().cloned().collect();
+
+    let documents = preprocess::pre_process(config, documents)?;
     let code_files = compile::forward::compile_all(config, &documents)?;
 
-    Ok((
-        documents.keys().cloned().collect(),
-        code_files.keys().cloned().collect(),
-    ))
+    Ok((original_documents, code_files.keys().cloned().collect()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,8 +319,7 @@ fn process_inputs_forward(
     config: &Config,
 ) -> Fallible<(HashSet<PathBuf>, HashSet<PathBuf>)> {
     let mut any_input = false;
-    let mut track_source_files = HashSet::new();
-    let mut track_code_files = HashMap::new();
+    let mut documents = HashMap::new();
     for pattern in input_patterns {
         let paths = glob::glob(&pattern)
             .map_err(|err| format!("Unable to process glob pattern \"{}\": {}", pattern, err))?;
@@ -334,19 +333,15 @@ fn process_inputs_forward(
                 any_input = true;
                 let file_name = PathBuf::from(&input);
 
-                compile::forward::compile_all(
-                    &config,
-                    &file_name,
-                    &mut track_source_files,
-                    &mut track_code_files,
-                )
-                .map_err(|err| {
-                    format!(
-                        "Failed to compile source file \"{}\": {}",
-                        file_name.display(),
-                        err
-                    )
-                })?
+                compile::forward::collect_documents(&config, &file_name, &mut documents).map_err(
+                    |err| {
+                        format!(
+                            "Failed to compile source file \"{}\": {}",
+                            file_name.display(),
+                            err
+                        )
+                    },
+                )?;
             }
         }
     }
@@ -361,8 +356,10 @@ fn process_inputs_forward(
         .into());
     }
 
+    let code_files = compile::forward::compile_all(config, &documents)?;
+
     Ok((
-        track_source_files,
-        track_code_files.keys().cloned().collect(),
+        documents.keys().cloned().collect(),
+        code_files.keys().cloned().collect(),
     ))
 }

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use yarner_lib::Document;
+
+use crate::config::Config;
+use crate::util::Fallible;
+
+pub fn pre_process(
+    config: &Config,
+    documents: HashMap<PathBuf, Document>,
+) -> Fallible<HashMap<PathBuf, Document>> {
+    let mut docs = documents;
+    for (name, proc) in &config.preprocessor {
+        let json = yarner_lib::to_json(proc, &docs)?;
+
+        let command = proc
+            .get("command")
+            .and_then(|cmd| cmd.as_str().map(|s| s.to_owned()))
+            .unwrap_or_else(|| format!("yarner-{}", name));
+
+        let mut child = Command::new(&command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(|err| format_error(err.into(), &command))?;
+
+        {
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or("Unable to access child process stdin.")
+                .map_err(|err| format_error(err.into(), &command))?;
+            stdin
+                .write_all(json.as_bytes())
+                .map_err(|err| format_error(err.into(), &command))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|err| format_error(err.into(), &command))?;
+        let out_json =
+            String::from_utf8(output.stdout).map_err(|err| format_error(err.into(), &command))?;
+
+        let (_, new_docs) =
+            yarner_lib::from_json(&out_json).map_err(|err| format_error(err.into(), &command))?;
+        docs = new_docs;
+    }
+    Ok(docs)
+}
+
+fn format_error(err: Box<dyn Error>, name: &str) -> String {
+    format!("Failed to run command '{}': {}", name, err.to_string())
+}

--- a/yarner-lib/src/lib.rs
+++ b/yarner-lib/src/lib.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::Read;
 use std::path::PathBuf;
 use toml::Value;
 
@@ -7,17 +6,11 @@ mod document;
 
 pub use document::*;
 
-pub fn to_json(
-    config: &Value,
-    documents: &HashMap<PathBuf, Document>,
-) -> serde_json::Result<String> {
-    serde_json::to_string_pretty(&(config, documents))
+pub fn parse_input() -> serde_json::Result<(Value, HashMap<PathBuf, Document>)> {
+    serde_json::from_reader(std::io::stdin())
 }
 
-pub fn from_json(json: &str) -> serde_json::Result<(Value, HashMap<PathBuf, Document>)> {
-    serde_json::from_str(json)
-}
-
-pub fn parse_input<R: Read>(reader: R) -> serde_json::Result<(Value, HashMap<PathBuf, Document>)> {
-    serde_json::from_reader(reader)
+pub fn write_output(documents: &HashMap<PathBuf, Document>) -> serde_json::Result<()> {
+    println!("{}", serde_json::to_string_pretty(documents)?);
+    Ok(())
 }


### PR DESCRIPTION
Send all documents through all pre-processors before "compiling" into code and docs output.

Example pre-processors that use this implementation:

* [yarner-block-links](https://github.com/mlange-42/yarner-block-links)
* [yarner-fold-code](https://github.com/mlange-42/yarner-fold-code)

Fixes #53.