### PR TITLE
Add code block field `is_file`

### DIFF
--- a/schemas/yarner-data.json
+++ b/schemas/yarner-data.json
@@ -29,25 +29,30 @@
       "description": "A `CodeBlock` is a block of code as defined by the input format.",
       "type": "object",
       "required": [
-        "alternative",
-        "hidden",
         "indent",
+        "is_alternative",
+        "is_file",
+        "is_hidden",
         "is_unnamed",
         "line_number",
         "source"
       ],
       "properties": {
-        "alternative": {
-          "description": "Marks the code block as fenced by alternative sequence",
-          "type": "boolean"
-        },
-        "hidden": {
-          "description": "Marks the code block as hidden from docs",
-          "type": "boolean"
-        },
         "indent": {
           "description": "The indent of this code block is in the documentation file",
           "type": "string"
+        },
+        "is_alternative": {
+          "description": "Marks the code block as fenced by alternative sequence",
+          "type": "boolean"
+        },
+        "is_file": {
+          "description": "Marks the code block as a file-based entrypoint",
+          "type": "boolean"
+        },
+        "is_hidden": {
+          "description": "Marks the code block as hidden from docs",
+          "type": "boolean"
         },
         "is_unnamed": {
           "description": "Whether the code block was originally unnamed",
@@ -110,6 +115,9 @@
         }
       }
     },
+    "Config": {
+      "type": "object"
+    },
     "Context": {
       "type": "object",
       "required": [
@@ -120,7 +128,11 @@
       "properties": {
         "config": {
           "description": "Configuration of the pre-processor",
-          "type": "object"
+          "allOf": [
+            {
+              "$ref": "#/definitions/Config"
+            }
+          ]
         },
         "name": {
           "description": "Name of the pre-processor",

--- a/src/compile/forward.rs
+++ b/src/compile/forward.rs
@@ -61,7 +61,7 @@ fn compile(
 ) -> Fallible {
     println!("Compiling file {}", file_name.display());
 
-    let mut entries = super::entry_points(document, &config.parser.file_prefix);
+    let mut entries = document.entry_points();
 
     let file_name_without_ext = file_name.with_extension("");
     entries.insert(

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use yarner_lib::{Document, Node};
 
 pub mod forward;
@@ -14,26 +12,4 @@ fn set_source(document: &mut Document, source: &str) {
             }
         }
     }
-}
-
-/// Finds all file-specific entry points
-fn entry_points<'a>(
-    document: &'a Document,
-    file_prefix: &str,
-) -> HashMap<Option<&'a str>, (&'a Path, Option<PathBuf>)> {
-    let mut entries = HashMap::new();
-    for block in document.code_blocks() {
-        if let Some(name) = block.name.as_deref() {
-            if let Some(rest) = name.strip_prefix(file_prefix) {
-                entries.insert(
-                    Some(name),
-                    (
-                        Path::new(rest),
-                        block.source_file.as_ref().map(|file| file.into()),
-                    ),
-                );
-            }
-        }
-    }
-    entries
 }

--- a/src/compile/reverse.rs
+++ b/src/compile/reverse.rs
@@ -53,7 +53,7 @@ fn compile(
 ) {
     println!("Compiling file {}", file_name.display());
 
-    let mut entries = super::entry_points(document, &config.parser.file_prefix);
+    let mut entries = document.entry_points();
 
     let file_name_without_ext = file_name.with_extension("");
     entries.insert(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,7 +26,7 @@ pub fn parse(
 
     for (line_number, line) in input.lines().enumerate() {
         let (is_code, is_alt_fenced_code) = if let Some(Node::Code(code_block)) = nodes.last() {
-            (true, code_block.alternative)
+            (true, code_block.is_alternative)
         } else {
             (false, false)
         };
@@ -147,12 +147,21 @@ fn extend_code(line: &str, settings: &ParserSettings, block: &mut CodeBlock) {
     if block.source.is_empty() && line.trim().starts_with(&settings.block_name_prefix) {
         let name = line.trim()[settings.block_name_prefix.len()..].trim();
 
-        if let Some(stripped) = name.strip_prefix(&settings.hidden_prefix) {
-            block.name = Some(stripped.to_string());
-            block.hidden = true;
+        let name = if let Some(stripped) = name.strip_prefix(&settings.hidden_prefix) {
+            block.is_hidden = true;
+            stripped
         } else {
-            block.name = Some(name.to_string());
+            name
         };
+
+        let name = if let Some(stripped) = name.strip_prefix(&settings.file_prefix) {
+            block.is_file = true;
+            stripped
+        } else {
+            name
+        };
+
+        block.name = Some(name.to_string());
     } else {
         let line = parse_line(&line[block.indent.len()..], settings);
         block.source.push(line);

--- a/src/print.rs
+++ b/src/print.rs
@@ -123,8 +123,16 @@ pub mod docs {
         if let Some(name) = &block.name {
             write!(
                 write,
-                "{}{} {}{}",
-                indent, settings.block_name_prefix, name, newline,
+                "{}{} {}{}{}",
+                indent,
+                settings.block_name_prefix,
+                if block.is_file {
+                    &settings.file_prefix
+                } else {
+                    ""
+                },
+                name,
+                newline,
             )
             .unwrap();
         }

--- a/src/print.rs
+++ b/src/print.rs
@@ -23,7 +23,7 @@ pub mod docs {
                     .unwrap();
                 }
                 Node::Code(code_block) => {
-                    if !code_block.hidden {
+                    if !code_block.is_hidden {
                         print_code_block(
                             code_block,
                             settings,
@@ -109,7 +109,7 @@ pub mod docs {
         newline: &str,
         write: &mut impl Write,
     ) {
-        let fence_sequence = if block.alternative {
+        let fence_sequence = if block.is_alternative {
             &settings.fence_sequence_alt
         } else {
             &settings.fence_sequence
@@ -144,7 +144,7 @@ pub mod docs {
         newline: &str,
         write: &mut impl Write,
     ) {
-        let fence_sequence = if block.alternative {
+        let fence_sequence = if block.is_alternative {
             &settings.fence_sequence_alt
         } else {
             &settings.fence_sequence
@@ -157,8 +157,11 @@ pub mod docs {
 
         if let Some(name) = &block.name {
             write!(write, "{}{} ", indent, settings.block_name_prefix).unwrap();
-            if block.hidden {
+            if block.is_hidden {
                 write!(write, "{}", settings.hidden_prefix).unwrap();
+            }
+            if block.is_file {
+                write!(write, "{}", settings.file_prefix).unwrap();
             }
             write!(write, "{}{}", name, newline).unwrap();
         }
@@ -217,8 +220,9 @@ pub mod docs {
                 name: Some("Code block".to_string()),
                 is_unnamed: false,
                 language: Some("rust".to_string()),
-                hidden: false,
-                alternative: false,
+                is_file: false,
+                is_hidden: false,
+                is_alternative: false,
                 source_file: None,
                 source: vec![
                     Line::Source {


### PR DESCRIPTION
Allows to analyze the document without `ParserSettings`

Renamed boolean fields in CodeBlock to `is_...`