### PR TITLE
Watch mode - less errors, more warnings

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -18,6 +18,7 @@ use crate::{
 pub fn run_with_args(
     matches: &ArgMatches,
     reverse_mode: Option<bool>,
+    strict: bool,
 ) -> Fallible<(PathBuf, HashSet<PathBuf>, HashSet<PathBuf>, bool)> {
     let config_path = matches.value_of("config").unwrap();
     let mut config = Config::read(config_path)
@@ -83,7 +84,7 @@ pub fn run_with_args(
     let (mut source_files, mut code_files) = if reverse {
         process_inputs_reverse(&input_patterns, &config)?
     } else {
-        process_inputs_forward(&input_patterns, &config)?
+        process_inputs_forward(&input_patterns, &config, strict)?
     };
 
     if let (Some(code_dir), Some(code_file_patterns)) =
@@ -242,6 +243,7 @@ fn process_inputs_reverse(
 fn process_inputs_forward(
     input_patterns: &[String],
     config: &Config,
+    strict: bool,
 ) -> Fallible<(HashSet<PathBuf>, HashSet<PathBuf>)> {
     let mut any_input = false;
     let mut documents = HashMap::new();
@@ -288,7 +290,7 @@ fn process_inputs_forward(
 
     let code_files = compile::forward::extract_code_all(config, &documents)?;
 
-    let documents = plugin::run_plugins(config, documents)?;
+    let documents = plugin::run_plugins(config, documents, strict)?;
     compile::forward::write_documentation_all(config, &documents)?;
 
     Ok((source_file, code_files.keys().cloned().collect()))

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -19,7 +19,7 @@ pub fn run_with_args(
     matches: &ArgMatches,
     reverse_mode: Option<bool>,
     strict: bool,
-) -> Fallible<(PathBuf, HashSet<PathBuf>, HashSet<PathBuf>, bool)> {
+) -> Fallible<(PathBuf, HashSet<PathBuf>, HashSet<PathBuf>)> {
     let config_path = matches.value_of("config").unwrap();
     let mut config = Config::read(config_path)
         .map_err(|err| format!("Could not read config file \"{}\": {}", config_path, err))?;
@@ -32,7 +32,12 @@ pub fn run_with_args(
     let has_reverse_config = config.has_reverse_config();
 
     if reverse && !has_reverse_config {
-        return Err("Reverse mode not enabled for any language. Stopping.".into());
+        let message = "Reverse mode not enabled for any language. Stopping.";
+        if strict {
+            return Err(message.into());
+        } else {
+            eprintln!("Warning: {}", message);
+        }
     }
 
     let lock_path = PathBuf::from(config_path).with_extension("lock");
@@ -124,7 +129,6 @@ pub fn run_with_args(
             .map(|path| root_path.join(path))
             .collect(),
         code_files.iter().map(|path| root_path.join(path)).collect(),
-        has_reverse_config,
     ))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,8 +108,7 @@ fn run() -> Fallible {
     }
 
     let curr_dir = env::current_dir()?;
-    let (config, mut watch_forward, watch_reverse, has_reverse_conf) =
-        cmd::run_with_args(&matches, None, true)?;
+    let (config, mut watch_forward, watch_reverse) = cmd::run_with_args(&matches, None, true)?;
     env::set_current_dir(&curr_dir)?;
 
     if matches.subcommand_matches("watch").is_some() {
@@ -118,7 +117,6 @@ fn run() -> Fallible {
             matches,
             watch_forward.into_iter(),
             watch_reverse.into_iter(),
-            has_reverse_conf,
         )?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn run() -> Fallible {
 
     let curr_dir = env::current_dir()?;
     let (config, mut watch_forward, watch_reverse, has_reverse_conf) =
-        cmd::run_with_args(&matches, None)?;
+        cmd::run_with_args(&matches, None, true)?;
     env::set_current_dir(&curr_dir)?;
 
     if matches.subcommand_matches("watch").is_some() {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,6 +12,7 @@ use crate::util::Fallible;
 pub fn run_plugins(
     config: &Config,
     documents: HashMap<PathBuf, Document>,
+    strict: bool,
 ) -> Fallible<HashMap<PathBuf, Document>> {
     let mut docs = documents;
     for (name, config) in &config.plugin {
@@ -50,7 +51,7 @@ pub fn run_plugins(
             .spawn()
             .map_err(|err| format_error(err.into(), &command))?;
 
-        docs = if let Err(err) = child
+        let has_input = if let Err(err) = child
             .stdin
             .as_mut()
             .ok_or_else(|| "No stdin available.".to_string())
@@ -65,26 +66,47 @@ pub fn run_plugins(
                 err.to_string()
             );
 
-            data.documents
+            false
         } else {
-            let output = child
-                .wait_with_output()
-                .map_err(|err| format_error(err.into(), &command))?;
+            true
+        };
 
-            if !output.status.success() {
-                return Err(format!("Plugin '{}' exits with error.", name).into());
-            }
+        let output = child
+            .wait_with_output()
+            .map_err(|err| format_error(err.into(), &command))?;
 
-            let out_json = String::from_utf8(output.stdout)
-                .map_err(|err| format_error(err.into(), &command))?;
+        docs = if output.status.success() {
+            if has_input {
+                let out_json = String::from_utf8(output.stdout)
+                    .map_err(|err| format_error(err.into(), &command))?;
 
-            match from_json(&out_json) {
-                Ok(context) => context.documents,
-                Err(err) => {
-                    eprintln!("Warning: Invalid output from plugin '{}': {}", name, err);
-                    data.documents
+                match from_json(&out_json) {
+                    Ok(context) => context.documents,
+                    Err(err) => {
+                        eprintln!("Warning: Invalid output from plugin '{}': {}", name, err);
+                        data.documents
+                    }
                 }
+            } else {
+                print!("{}", String::from_utf8(output.stdout)?);
+                data.documents
             }
+        } else {
+            print!("{}", String::from_utf8(output.stdout)?);
+
+            let message = format!(
+                "Plugin '{}' exits with error {}.",
+                name,
+                output.status.code().unwrap_or(1)
+            );
+
+            if strict {
+                return Err(message.into());
+            } else {
+                eprintln!("Warning: {}", message);
+            }
+
+            data.documents
         }
     }
     Ok(docs)

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -53,7 +53,7 @@ pub fn watch(
 
             let curr_dir = env::current_dir()?;
             let (config, mut watch_sources_new, watch_code_new, _has_reverse) =
-                cmd::run_with_args(&args, Some(change == ChangeType::Code))?;
+                cmd::run_with_args(&args, Some(change == ChangeType::Code), false)?;
             env::set_current_dir(&curr_dir)?;
 
             watch_sources_new.insert(config);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -23,7 +23,6 @@ pub fn watch(
     args: ArgMatches,
     watch_sources: impl Iterator<Item = PathBuf>,
     watch_code: impl Iterator<Item = PathBuf>,
-    allow_reverse: bool,
 ) -> Fallible {
     println!("Watching for changes...");
 
@@ -39,33 +38,31 @@ pub fn watch(
     )?;
 
     for change in rx_changes {
-        if allow_reverse || change == ChangeType::Sources {
-            println!(
-                "{} changed. Re-building...",
-                if change == ChangeType::Sources {
-                    "Sources"
-                } else {
-                    "Code"
-                }
-            );
+        println!(
+            "{} changed. Re-building...",
+            if change == ChangeType::Sources {
+                "Sources"
+            } else {
+                "Code"
+            }
+        );
 
-            suspend.store(true, Ordering::SeqCst);
+        suspend.store(true, Ordering::SeqCst);
 
-            let curr_dir = env::current_dir()?;
-            let (config, mut watch_sources_new, watch_code_new, _has_reverse) =
-                cmd::run_with_args(&args, Some(change == ChangeType::Code), false)?;
-            env::set_current_dir(&curr_dir)?;
+        let curr_dir = env::current_dir()?;
+        let (config, mut watch_sources_new, watch_code_new) =
+            cmd::run_with_args(&args, Some(change == ChangeType::Code), false)?;
+        env::set_current_dir(&curr_dir)?;
 
-            watch_sources_new.insert(config);
+        watch_sources_new.insert(config);
 
-            update_watcher(&mut sw, &watch_sources_old, &watch_sources_new)?;
-            update_watcher(&mut cw, &watch_code_old, &watch_code_new)?;
+        update_watcher(&mut sw, &watch_sources_old, &watch_sources_new)?;
+        update_watcher(&mut cw, &watch_code_old, &watch_code_new)?;
 
-            suspend.store(false, Ordering::SeqCst);
+        suspend.store(false, Ordering::SeqCst);
 
-            watch_sources_old = watch_sources_new;
-            watch_code_old = watch_code_new;
-        }
+        watch_sources_old = watch_sources_new;
+        watch_code_old = watch_code_new;
     }
 
     Ok(())


### PR DESCRIPTION
Make using watch more convenient by not aborting on "recoverable" errors

* Warn instead of abort on plugin i/o problem (allow for plugins not modifying the docs)
* Warn instead of abort on plugin returning with error, in watch mode (avoid exiting watch mode)
* Warn instead of abort on unconfigured reverse mode, in watch mode (allow to enable reverse mode while watching)